### PR TITLE
Fix username update bug for MySQL

### DIFF
--- a/src/main/java/net/akarian/auctionhouse/events/UserEvents.java
+++ b/src/main/java/net/akarian/auctionhouse/events/UserEvents.java
@@ -18,17 +18,7 @@ public class UserEvents implements Listener {
         Player p = e.getPlayer();
         UserManager um = AuctionHouse.getInstance().getUserManager();
 
-        Bukkit.getScheduler().runTaskAsynchronously(AuctionHouse.getInstance(), () -> {
-            User user = um.loadUser(p.getUniqueId());
-
-            if (!p.getName().equals(user.getUsername())) {
-                final String oldUsername = user.getUsername();
-                user.setUsername(p.getName());
-                user.getUserSettings().saveUsername();
-                AuctionHouse.getInstance().getChat().log("Saved new username for " + p.getUniqueId() + " - New: " + user.getUsername() + " Old: " + oldUsername, AuctionHouse.getInstance().isDebug());
-            }
-        });
-
+        um.loadUser(p.getUniqueId());
 
     }
 

--- a/src/main/java/net/akarian/auctionhouse/users/User.java
+++ b/src/main/java/net/akarian/auctionhouse/users/User.java
@@ -65,14 +65,6 @@ public class User {
                             e.printStackTrace();
                         }
             }
-
-            OfflinePlayer offPlayer = Bukkit.getOfflinePlayer(uuid);
-            if (!this.getUsername().equals(offPlayer.getName())) {
-                final String oldUsername = this.getUsername();
-                this.setUsername(offPlayer.getName());
-                this.getUserSettings().saveUsername();
-                AuctionHouse.getInstance().getChat().log("Saved new username for " + uuid + " - New: " + this.getUsername() + " Old: " + oldUsername, AuctionHouse.getInstance().isDebug());
-            }
         });
     }
 

--- a/src/main/java/net/akarian/auctionhouse/users/UserSettings.java
+++ b/src/main/java/net/akarian/auctionhouse/users/UserSettings.java
@@ -7,6 +7,7 @@ import net.akarian.auctionhouse.listings.Listing;
 import net.akarian.auctionhouse.utils.FileManager;
 import net.akarian.auctionhouse.utils.MySQL;
 import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.configuration.file.YamlConfiguration;
 
 import java.sql.PreparedStatement;
@@ -115,6 +116,16 @@ public class UserSettings {
                 if (!usersFile.contains(user.getUuid().toString() + ".Username")) {
                     usersFile.set(user.getUuid().toString() + ".Username", Objects.requireNonNull(Bukkit.getPlayer(user.getUuid())).getName());
                 }
+
+                Bukkit.getScheduler().runTaskAsynchronously(AuctionHouse.getInstance(), () -> {
+                    OfflinePlayer offPlayer = Bukkit.getOfflinePlayer(user.getUuid()); // Running async because this makes an api call
+                    if (!user.getUsername().equals(offPlayer.getName())) {
+                        final String oldUsername = user.getUsername();
+                        user.setUsername(offPlayer.getName());
+                        user.getUserSettings().saveUsername();
+                        AuctionHouse.getInstance().getChat().log("Saved new username for " + user.getUuid() + " - New: " + user.getUsername() + " Old: " + oldUsername, AuctionHouse.getInstance().isDebug());
+                    }
+                });
                 break;
             case MYSQL:
                 Bukkit.getScheduler().runTaskAsynchronously(AuctionHouse.getInstance(), () -> {
@@ -134,6 +145,14 @@ public class UserSettings {
                             alertListingBought = rs.getBoolean(7);
                             autoConfirmListing = rs.getBoolean(8);
                             sounds = rs.getBoolean(9);
+                        }
+
+                        OfflinePlayer offPlayer = Bukkit.getOfflinePlayer(user.getUuid());
+                        if (!user.getUsername().equals(offPlayer.getName())) {
+                            final String oldUsername = user.getUsername();
+                            user.setUsername(offPlayer.getName());
+                            user.getUserSettings().saveUsername();
+                            AuctionHouse.getInstance().getChat().log("Saved new username for " + user.getUuid() + " - New: " + user.getUsername() + " Old: " + oldUsername, AuctionHouse.getInstance().isDebug());
                         }
 
                     } catch (Exception e) {


### PR DESCRIPTION
These commits help fix a bug caused by the way user settings was loaded when using MySQL. The user settings were loaded in an async thread which caused them not to be loaded by the time UserEvents class was trying to access it to update the username. 

This PR fixes this by instead updating the username in the load user settings function. 